### PR TITLE
Add LD_LIBRARY_PATH to spawn command

### DIFF
--- a/libs/processRunner.js
+++ b/libs/processRunner.js
@@ -58,7 +58,9 @@ function makeRunner(command, args, requiredOptions = [], outputTestFile = null){
         }
 
         // Launch
-        let childProcess = spawn(command, commandArgs);
+        let childProcess = spawn(command, commandArgs, {
+            LD_LIBRARY_PATH: path.join(config.odm_path, "SuperBuild", "install", "lib")
+        });
 
         childProcess
             .on('exit', (code, signal) => done(null, code, signal))

--- a/libs/processRunner.js
+++ b/libs/processRunner.js
@@ -59,7 +59,9 @@ function makeRunner(command, args, requiredOptions = [], outputTestFile = null){
 
         // Launch
         let childProcess = spawn(command, commandArgs, {
-            LD_LIBRARY_PATH: path.join(config.odm_path, "SuperBuild", "install", "lib")
+            env:{
+                LD_LIBRARY_PATH: path.join(config.odm_path, "SuperBuild", "install", "lib")
+            }
         });
 
         childProcess

--- a/libs/processRunner.js
+++ b/libs/processRunner.js
@@ -22,6 +22,7 @@ let assert = require('assert');
 let spawn = require('child_process').spawn;
 let config = require('../config.js');
 let logger = require('./logger');
+let utils = require('./utils');
 
 
 function makeRunner(command, args, requiredOptions = [], outputTestFile = null){
@@ -58,11 +59,9 @@ function makeRunner(command, args, requiredOptions = [], outputTestFile = null){
         }
 
         // Launch
-        let childProcess = spawn(command, commandArgs, {
-            env:{
-                LD_LIBRARY_PATH: path.join(config.odm_path, "SuperBuild", "install", "lib")
-            }
-        });
+        const env = utils.clone(process.env);
+        env.LD_LIBRARY_PATH = path.join(config.odm_path, "SuperBuild", "install", "lib");
+        let childProcess = spawn(command, commandArgs, { env });
 
         childProcess
             .on('exit', (code, signal) => done(null, code, signal))

--- a/libs/utils.js
+++ b/libs/utils.js
@@ -44,5 +44,9 @@ module.exports = {
             const safeSuffix = path.normalize(p).replace(/^(\.\.(\/|\\|$))+/, '');
             return path.join('./', safeSuffix);
         });
+    },
+
+    clone: function(json){
+        return JSON.parse(JSON.stringify(json));
     }
 };

--- a/services/nodeodm.service
+++ b/services/nodeodm.service
@@ -7,6 +7,7 @@ PIDFile=/run/nodeodm.pid
 User=odm
 Group=odm
 WorkingDirectory=/www
+Environment="HOME=/www/data"
 ExecStart=/usr/bin/node index.js
 ExecStop=/bin/kill -s QUIT $MAINPID
 Restart=on-failure

--- a/services/nodeodm.service
+++ b/services/nodeodm.service
@@ -7,7 +7,6 @@ PIDFile=/run/nodeodm.pid
 User=odm
 Group=odm
 WorkingDirectory=/www
-Environment="HOME=/www/data"
 ExecStart=/usr/bin/node index.js
 ExecStop=/bin/kill -s QUIT $MAINPID
 Restart=on-failure


### PR DESCRIPTION
Allows `postprocess.sh` to use commands which might rely on libraries in LD_LIBRARY_PATH.

Affects native installs only.