### PR TITLE
Catch ENOMEM

### DIFF
--- a/libs/processRunner.js
+++ b/libs/processRunner.js
@@ -61,16 +61,21 @@ function makeRunner(command, args, requiredOptions = [], outputTestFile = null){
         // Launch
         const env = utils.clone(process.env);
         env.LD_LIBRARY_PATH = path.join(config.odm_path, "SuperBuild", "install", "lib");
-        let childProcess = spawn(command, commandArgs, { env });
-
-        childProcess
-            .on('exit', (code, signal) => done(null, code, signal))
-            .on('error', done);
-
-        childProcess.stdout.on('data', chunk => outputReceived(chunk.toString()));
-        childProcess.stderr.on('data', chunk => outputReceived(chunk.toString()));
-
-        return childProcess;
+        
+        try{
+            let childProcess = spawn(command, commandArgs, { env });
+            childProcess
+                .on('exit', (code, signal) => done(null, code, signal))
+                .on('error', done);
+    
+            childProcess.stdout.on('data', chunk => outputReceived(chunk.toString()));
+            childProcess.stderr.on('data', chunk => outputReceived(chunk.toString()));
+            return childProcess;
+        }catch(e){
+            // Catch errors such as ENOMEM
+            logger.warn(`Error: ${e.message}`);
+            done(e);
+        }
     };
 }
 


### PR DESCRIPTION
Fixes 
```
info: About to run: /var/www/scripts/postprocess.sh data/349290aa-47fa-41d2-bb1d-c3c11d2ff91b
internal/child_process.js:366
    throw errnoException(err, 'spawn');
    ^

Error: spawn ENOMEM
    at ChildProcess.spawn (internal/child_process.js:366:11)
    at spawn (child_process.js:551:9)
    at Object.execFile (child_process.js:221:15)
    at exec (child_process.js:152:18)
    at process.nextTick (/var/www/node_modules/systeminformation/lib/memory.js:116:9)
    at process._tickCallback (internal/process/next_tick.js:61:11)
```