### PR TITLE
Fix gdal2tiles.py getting stuck on failure

### DIFF
--- a/libs/Task.js
+++ b/libs/Task.js
@@ -31,6 +31,7 @@ const kill = require('tree-kill');
 const S3 = require('./S3');
 const request = require('request');
 const utils = require('./utils');
+const archiver = require('archiver');
 
 const statusCodes = require('./statusCodes');
 

--- a/scripts/gdal2tiles.py
+++ b/scripts/gdal2tiles.py
@@ -472,6 +472,8 @@ class Zoomify(object):
 class GDALError(Exception):
     pass
 
+import os
+main_pid = os.getpid()
 
 def exit_with_error(message, details=""):
     # Message printing and exit code kept from the way it worked using the OptionParser (in case
@@ -481,6 +483,8 @@ def exit_with_error(message, details=""):
     if details:
         sys.stderr.write("\n\n%s\n" % details)
 
+    import signal
+    os.kill(main_pid, signal.SIGINT)
     sys.exit(2)
 
 


### PR DESCRIPTION
Due to multithreading, calling sys.exit(2) kills the child process, leaving the parent waiting undefinitely.

Sending SIGINT to the parent fixes the problem.

`gdal2tiles.py` is being removed in the near term anyway.