### PR TITLE
Support s3ForcePathStyle AWS config option

### DIFF
--- a/config.js
+++ b/config.js
@@ -48,6 +48,7 @@ Options:
 	--s3_endpoint <url>	Specify a S3 endpoint (for example, nyc3.digitaloceanspaces.com) to upload completed task results to. (default: do not upload to S3)
 	--s3_bucket <bucket>	Specify a S3 bucket name where to upload completed task results to. (default: none)
 	--s3_access_key <key>	S3 access key, required if --s3_endpoint is set. (default: none)
+	--s3_force_path_style  Whether to force path style URLs for S3 objects. (default: false)
 	--s3_secret_key <secret>	S3 secret key, required if --s3_endpoint is set. (default: none) 
 	--s3_signature_version <version>	S3 signature version. (default: 4)
 	--s3_upload_everything	Upload all task results to S3. (default: upload only .zip archive and orthophoto)
@@ -109,6 +110,7 @@ config.maxImages = parseInt(argv.max_images || fromConfigFile("maxImages", "")) 
 config.webhook = argv.webhook || fromConfigFile("webhook", "");
 config.s3Endpoint = argv.s3_endpoint || fromConfigFile("s3Endpoint", "");
 config.s3Bucket = argv.s3_bucket || fromConfigFile("s3Bucket", "");
+config.s3ForcePathStyle = argv.s3_force_path_style || fromConfigFile("s3ForcePathStyle", false);
 config.s3AccessKey = argv.s3_access_key || fromConfigFile("s3AccessKey", process.env.AWS_ACCESS_KEY_ID || "")
 config.s3SecretKey = argv.s3_secret_key || fromConfigFile("s3SecretKey", process.env.AWS_SECRET_ACCESS_KEY || "")
 config.s3SignatureVersion = argv.s3_signature_version || fromConfigFile("s3SignatureVersion", "4")

--- a/libs/S3.js
+++ b/libs/S3.js
@@ -38,7 +38,8 @@ module.exports = {
                 endpoint: spacesEndpoint,
                 signatureVersion: ('v' + config.s3SignatureVersion) || 'v4',
                 accessKeyId: config.s3AccessKey,
-                secretAccessKey: config.s3SecretKey
+                secretAccessKey: config.s3SecretKey,
+                s3ForcePathStyle: config.s3ForcePathStyle,
             });
 
             // Test connection


### PR DESCRIPTION
Adds the following ways to configure S3 to use path style instead of subdomains.

* argument `--s3_force_path_style`
* config file option `s3ForcePathStyle`

Ref: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#s3ForcePathStyle-property