### PR TITLE
Delete previous directory if already exists during task init

### DIFF
--- a/libs/taskNew.js
+++ b/libs/taskNew.js
@@ -259,7 +259,16 @@ module.exports = {
                     if (req.files && req.files.length > 0) {
                         fs.stat(destPath, (err, stat) => {
                             if (err && err.code === 'ENOENT') cb();
-                            else cb(new Error(`Directory exists (should not have happened)`));
+                            else{
+                                // Directory already exists, this could happen
+                                // if a previous attempt at upload failed and the user
+                                // used set-uuid to specify the same UUID over the previous run
+                                // Try to remove it
+                                removeDirectory(destPath, err => {
+                                    if (err) cb(new Error(`Directory exists and we couldn't remove it.`));
+                                    else cb();
+                                });
+                            } 
                         });
                     } else {
                         cb();


### PR DESCRIPTION
If a client uses `set-uuid` for a previously incomplete task upload, NodeODM will quit because the folder already exists.

This was done so that a user couldn't potentially create two tasks with the same UUID.

This is not a big problem for 99% of the cases, because UUIDs are hidden and this is only an issue when `set-uuid` is used (ClusterODM).