### PR TITLE
Automatically set --cog if postprocessing is required

### DIFF
--- a/libs/Task.js
+++ b/libs/Task.js
@@ -84,6 +84,25 @@ module.exports = class Task{
                 }
             },
 
+            cb => {
+                // If we need to post process results
+                // if cog is supported (build cloud optimized geotiffs)
+                // we automatically add the cog option to the task options by default
+                if (this.skipPostProcessing) cb();
+                else{
+                    odmInfo.supportsOption("cog", (err, supported) => {
+                        if (err){
+                            console.warn(`Cannot check for supported option cog: ${err}`);
+                        }else if (supported){
+                            if (!this.options.find(opt => opt.name === "cog")){
+                                this.options.push({ name: 'cog', value: true });
+                            }
+                        }
+                        cb();
+                    });
+                }
+            },
+
             // Read images info
             cb => {
                 fs.readdir(this.getImagesFolderPath(), (err, files) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "NodeODM",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "REST API to access ODM",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Automatically set --cog when postprocessing is required. Avoids the need for WebODM to do this (local resources on the WebODM machines might have lack of resources to do this).﻿
