### PR TITLE
Add Intel Dockerfile and run as odm user.

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -4,7 +4,7 @@ MAINTAINER Piero Toffanin <pt@masseranolabs.com>
 EXPOSE 3000
 
 USER root
-RUN apt-get update && apt-get install -y curl gpg-agent
+RUN apt-get update && apt-get install -y curl gpg-agent ca-certificates
 RUN curl --silent --location https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs unzip p7zip-full && npm install -g nodemon && \
     ln -s /code/SuperBuild/install/bin/untwine /usr/bin/untwine && \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -4,7 +4,7 @@ MAINTAINER Piero Toffanin <pt@masseranolabs.com>
 EXPOSE 3000
 
 USER root
-RUN apt-get update && apt-get install -y curl gpg-agent ca-certificates
+RUN apt-get update && apt-get install -y curl gpg-agent
 RUN curl --silent --location https://deb.nodesource.com/setup_10.x | bash -
 RUN apt-get install -y nodejs unzip p7zip-full && npm install -g nodemon && \
     ln -s /code/SuperBuild/install/bin/untwine /usr/bin/untwine && \

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -15,8 +15,12 @@ RUN apt-get install -y nodejs unzip p7zip-full && npm install -g nodemon && \
 RUN mkdir /var/www
 
 WORKDIR "/var/www"
-COPY . /var/www
+COPY --chown=odm:odm . /var/www
 
 RUN npm install && mkdir -p tmp
+
+RUN chown -R /var/www
+
+USER odm
 
 ENTRYPOINT ["/usr/bin/node", "/var/www/index.js"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -15,11 +15,12 @@ RUN apt-get install -y nodejs unzip p7zip-full && npm install -g nodemon && \
 RUN mkdir /var/www
 
 WORKDIR "/var/www"
+RUN useradd -m -d "/home/odm" -s /bin/bash odm
 COPY --chown=odm:odm . /var/www
 
 RUN npm install && mkdir -p tmp
 
-RUN chown -R /var/www
+RUN chown -R odm:odm /var/www
 
 USER odm
 

--- a/Dockerfile.gpu.intel
+++ b/Dockerfile.gpu.intel
@@ -10,13 +10,14 @@ RUN apt-get remove --purge -y intel-opencl-icd && \
 RUN mkdir /tmp/opencl
 WORKDIR /tmp/opencl
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends ocl-icd-libopencl1 curl && \
+    apt-get install -y --no-install-recommends ocl-icd-libopencl1 wget && \
     rm -rf /var/lib/apt/lists/* && \
-    curl -L "https://github.com/intel/compute-runtime/releases/download/19.41.14441/intel-gmmlib_19.3.2_amd64.deb" --output "intel-gmmlib_19.3.2_amd64.deb" && \
-    curl -L "https://github.com/intel/compute-runtime/releases/download/19.41.14441/intel-igc-core_1.0.2597_amd64.deb" --output "intel-igc-core_1.0.2597_amd64.deb" && \
-    curl -L "https://github.com/intel/compute-runtime/releases/download/19.41.14441/intel-igc-opencl_1.0.2597_amd64.deb" --output "intel-igc-opencl_1.0.2597_amd64.deb" && \
-    curl -L "https://github.com/intel/compute-runtime/releases/download/19.41.14441/intel-opencl_19.41.14441_amd64.deb" --output "intel-opencl_19.41.14441_amd64.deb" && \
-    curl -L "https://github.com/intel/compute-runtime/releases/download/19.41.14441/intel-ocloc_19.41.14441_amd64.deb" --output "intel-ocloc_19.04.12237_amd64.deb" && \
+    wget https://github.com/intel/compute-runtime/releases/download/21.38.21026/intel-gmmlib_21.2.1_amd64.deb && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.8708/intel-igc-core_1.0.8708_amd64.deb && \
+    wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.8708/intel-igc-opencl_1.0.8708_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/21.38.21026/intel-opencl_21.38.21026_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/21.38.21026/intel-ocloc_21.38.21026_amd64.deb && \
+    wget https://github.com/intel/compute-runtime/releases/download/21.38.21026/intel-level-zero-gpu_1.2.21026_amd64.deb && \
     dpkg -i /tmp/opencl/*.deb && \
     ldconfig && \
     rm -Rf /tmp/opencl

--- a/Dockerfile.gpu.intel
+++ b/Dockerfile.gpu.intel
@@ -21,7 +21,6 @@ RUN apt-get update && \
     dpkg -i /tmp/opencl/*.deb && \
     ldconfig && \
     rm -Rf /tmp/opencl
-WORKDIR /var/www
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends clinfo
@@ -30,6 +29,7 @@ RUN usermod -aG video,users odm
 RUN usermod -aG video,users,odm root
 RUN if [ "${RENDER_GROUP_ID}" -ne 0 ]; then groupadd -g "${RENDER_GROUP_ID}" render; usermod -aG render odm; fi
 
+WORKDIR /var/www
 USER odm
 
 ENTRYPOINT ["/usr/bin/node", "/var/www/index.js"]

--- a/Dockerfile.gpu.intel
+++ b/Dockerfile.gpu.intel
@@ -1,0 +1,34 @@
+FROM opendronemap/nodeodm:gpu
+
+ARG RENDER_GROUP_ID=0
+
+USER root
+
+RUN apt-get remove --purge -y intel-opencl-icd && \
+    apt-get autoremove -y
+
+RUN mkdir /tmp/opencl
+WORKDIR /tmp/opencl
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ocl-icd-libopencl1 curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -L "https://github.com/intel/compute-runtime/releases/download/19.41.14441/intel-gmmlib_19.3.2_amd64.deb" --output "intel-gmmlib_19.3.2_amd64.deb" && \
+    curl -L "https://github.com/intel/compute-runtime/releases/download/19.41.14441/intel-igc-core_1.0.2597_amd64.deb" --output "intel-igc-core_1.0.2597_amd64.deb" && \
+    curl -L "https://github.com/intel/compute-runtime/releases/download/19.41.14441/intel-igc-opencl_1.0.2597_amd64.deb" --output "intel-igc-opencl_1.0.2597_amd64.deb" && \
+    curl -L "https://github.com/intel/compute-runtime/releases/download/19.41.14441/intel-opencl_19.41.14441_amd64.deb" --output "intel-opencl_19.41.14441_amd64.deb" && \
+    curl -L "https://github.com/intel/compute-runtime/releases/download/19.41.14441/intel-ocloc_19.41.14441_amd64.deb" --output "intel-ocloc_19.04.12237_amd64.deb" && \
+    dpkg -i /tmp/opencl/*.deb && \
+    ldconfig && \
+    rm -Rf /tmp/opencl
+WORKDIR /var/www
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends clinfo
+
+RUN usermod -aG video,users odm
+RUN usermod -aG video,users,odm root
+RUN if [ "${RENDER_GROUP_ID}" -ne 0 ]; then groupadd -g "${RENDER_GROUP_ID}" render; fi
+
+USER odm
+
+ENTRYPOINT ["/usr/bin/node", "/var/www/index.js"]

--- a/Dockerfile.gpu.intel
+++ b/Dockerfile.gpu.intel
@@ -1,5 +1,7 @@
 FROM opendronemap/nodeodm:gpu
 
+EXPOSE 3000
+
 ARG RENDER_GROUP_ID=0
 
 USER root

--- a/Dockerfile.gpu.intel
+++ b/Dockerfile.gpu.intel
@@ -28,7 +28,7 @@ RUN apt-get update && \
 
 RUN usermod -aG video,users odm
 RUN usermod -aG video,users,odm root
-RUN if [ "${RENDER_GROUP_ID}" -ne 0 ]; then groupadd -g "${RENDER_GROUP_ID}" render; fi
+RUN if [ "${RENDER_GROUP_ID}" -ne 0 ]; then groupadd -g "${RENDER_GROUP_ID}" render; usermod -aG render odm; fi
 
 USER odm
 


### PR DESCRIPTION
This PR is in support of a [WebODM PR that adds Intel support and a Debian package to install/configure WebODM](https://github.com/OpenDroneMap/WebODM/pull/1066).

The primary reasons for these changes are to support Intel OpenCL, which required that the devices has matching permissions on the host and in the container, so I’ve also made the process run as an “odm” user, changing ownership of everything under /var/www to that user.

Specifically, it:
- adds an odm user to the base docker container, changes ownership, and runs as that user
- adds a specific docker container for Intel, which takes a build arg for the render group id which owns the device