### PR TITLE
Fix Intel docker image

### DIFF
--- a/Dockerfile.gpu.intel
+++ b/Dockerfile.gpu.intel
@@ -2,8 +2,6 @@ FROM opendronemap/nodeodm:gpu
 
 EXPOSE 3000
 
-ARG RENDER_GROUP_ID=0
-
 USER root
 
 RUN apt-get remove --purge -y intel-opencl-icd && \
@@ -29,7 +27,6 @@ RUN apt-get update && \
 
 RUN usermod -aG video,users odm
 RUN usermod -aG video,users,odm root
-RUN if [ "${RENDER_GROUP_ID}" -ne 0 ]; then groupadd -g "${RENDER_GROUP_ID}" render; usermod -aG render odm; fi
 
 WORKDIR /var/www
 USER odm

--- a/Dockerfile.gpu.intel.local
+++ b/Dockerfile.gpu.intel.local
@@ -1,4 +1,4 @@
-FROM opendronemap/nodeodm:gpu
+FROM opendronemap/nodeodm:gpu.intel
 
 EXPOSE 3000
 
@@ -6,29 +6,6 @@ ARG RENDER_GROUP_ID=0
 
 USER root
 
-RUN apt-get remove --purge -y intel-opencl-icd && \
-    apt-get autoremove -y
-
-RUN mkdir /tmp/opencl
-WORKDIR /tmp/opencl
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ocl-icd-libopencl1 wget && \
-    rm -rf /var/lib/apt/lists/* && \
-    wget https://github.com/intel/compute-runtime/releases/download/21.38.21026/intel-gmmlib_21.2.1_amd64.deb && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.8708/intel-igc-core_1.0.8708_amd64.deb && \
-    wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.8708/intel-igc-opencl_1.0.8708_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/21.38.21026/intel-opencl_21.38.21026_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/21.38.21026/intel-ocloc_21.38.21026_amd64.deb && \
-    wget https://github.com/intel/compute-runtime/releases/download/21.38.21026/intel-level-zero-gpu_1.2.21026_amd64.deb && \
-    dpkg -i /tmp/opencl/*.deb && \
-    ldconfig && \
-    rm -Rf /tmp/opencl
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends clinfo
-
-RUN usermod -aG video,users odm
-RUN usermod -aG video,users,odm root
 RUN if [ "${RENDER_GROUP_ID}" -ne 0 ]; then groupadd -g "${RENDER_GROUP_ID}" render; usermod -aG render odm; fi
 
 WORKDIR /var/www


### PR DESCRIPTION
The idea here is that `Dockerfile.gpu.intel` will be built and pushed to DockerHub.  The `Dockerfile.gpu.intel.local` image then extends that just to set the render group id for that particular host, so should be quick.