### PR TITLE
Change ownership of /code to work around PoissonRecon permission issue.

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -21,6 +21,7 @@ COPY --chown=odm:odm . /var/www
 RUN npm install && mkdir -p tmp
 
 RUN chown -R odm:odm /var/www
+RUN chown -R odm:odm /code
 
 USER odm
 


### PR DESCRIPTION
This is a regression that I caused while creating the WebODM Debian package.  It is the cause of the issue that I mentioned in [this post](https://community.opendronemap.org/t/orthophoto-failing-when-run-with-intel-hardware/8988/2).

`PoissonRecon` seems to be creating a temporary file relative to the executable, which the `odm` user doesn't have permission to do, so the meshing stage fails.  This essentially reverts permissions for that directory to before those changes.  I tried to limit this to a subdirectory, but it only works if the user can write to `/code`.