### PR TITLE
`noRetry` in response body to stop retrying in case of non-recoverable failure.

### DIFF
--- a/libs/taskNew.js
+++ b/libs/taskNew.js
@@ -143,7 +143,7 @@ module.exports = {
         if (req.files && req.files.length > 0){
             res.json({success: true});
         }else{
-            res.json({error: "Need at least 1 file."});
+            res.json({error: "Need at least 1 file.", noRetry: true});
         }
     },
 


### PR DESCRIPTION
This PR is made for this [issue](https://github.com/OpenDroneMap/PyODM/issues/16)
Through this PR, `noRetry` can be added to response bodies where they are sent when a non-recoverable failure occurs.
To make it work, a [PR](https://github.com/OpenDroneMap/PyODM/pull/22) is also made to PyODM so that it can stop retrying the uploading.