### PR TITLE
Import missing logger library

### DIFF
--- a/libs/taskNew.js
+++ b/libs/taskNew.js
@@ -31,6 +31,7 @@ const odmInfo = require('./odmInfo');
 const request = require('request');
 const ziputils = require('./ziputils');
 const statusCodes = require('./statusCodes');
+const logger = require('./logger');
 
 const download = function(uri, filename, callback) {
     request.head(uri, function(err, res, body) {


### PR DESCRIPTION
Logger is used on line 305-306 but is not imported, that's why NodeODM crashes while it's retrying to move the files.