### PR TITLE
Create initial Apptainer definition file and some initial instructions on running Apptainer on HPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run -p 3000:3000 opendronemap/nodeodm
 docker-machine ip
 ```
 
-* A rootless alternative to Docker is using [Apptainer](https://apptainer.org/). In order to run NodeODM together with ClusterODM on HPC, we need a rootless alternative to Docker, and that's where Apptainer comes in to play. From the Linux command line, run the following commands to host a NodeODM instance:
+* A rootless alternative to Docker is using [Apptainer](https://apptainer.org/). In order to run NodeODM together with ClusterODM on HPC, we need a rootless alternative to Docker, and that's where Apptainer comes in to play. From the Linux command line, cd into the NodeODM folder and run the following commands to host a NodeODM instance:
 
 ```
 apptainer build --sandbox node/ singularity.def

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ docker run -p 3000:3000 opendronemap/nodeodm
 docker-machine ip
 ```
 
-* A rootless alternative to Docker is using [Apptainer](https://apptainer.org/). In order to run NodeODM together with ClusterODM on HPC, we need a rootless alternative to Docker, and that's where Apptainer comes in to play. From the Linux command line, run:
+* A rootless alternative to Docker is using [Apptainer](https://apptainer.org/). In order to run NodeODM together with ClusterODM on HPC, we need a rootless alternative to Docker, and that's where Apptainer comes in to play. From the Linux command line, run the following commands to host a NodeODM instance:
 
 ```
 apptainer build --sandbox node/ singularity.def

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ docker run -p 3000:3000 opendronemap/nodeodm
 docker-machine ip
 ```
 
+* A rootless alternative to Docker is using [Apptainer](https://apptainer.org/). In order to run NodeODM together with ClusterODM on HPC, we need a rootless alternative to Docker, and that's where Apptainer comes in to play. From the Linux command line, run:
+
+```
+apptainer build --sandbox node/ singularity.def
+apptainer run --writable node/ 
+```
+
 Linux users can connect to 127.0.0.1.
 
 * Open a Web Browser to `http://<yourDockerMachineIp>:3000`

--- a/singularity.def
+++ b/singularity.def
@@ -1,0 +1,34 @@
+Bootstrap: docker
+From: opendronemap/odm:latest
+Stage: spython-base
+
+%files
+. /var/www
+%labels
+MAINTAINER Piero Toffanin <pt@masseranolabs.com>
+%post
+
+# EXPOSE 3000
+
+su -  root # USER root
+apt-get update && apt-get install -y curl gpg-agent
+curl --silent --location https://deb.nodesource.com/setup_14.x | bash -
+apt-get install -y nodejs unzip p7zip-full && npm install -g nodemon && \
+ln -s /code/SuperBuild/install/bin/untwine /usr/bin/untwine && \
+ln -s /code/SuperBuild/install/bin/entwine /usr/bin/entwine && \
+ln -s /code/SuperBuild/install/bin/pdal /usr/bin/pdal
+
+
+mkdir -p /var/www
+
+mkdir -p "/var/www"
+cd "/var/www"
+
+npm install --production && mkdir -p tmp
+
+%runscript
+cd "/var/www"
+exec /usr/bin/node /var/www/index.js "$@"
+%startscript
+cd "/var/www"
+exec /usr/bin/node /var/www/index.js "$@"


### PR DESCRIPTION
We'll be using Apptainer as an alternative to Docker in order to run ODM on the HPC. Some instructions on how to build and run Apptainer containers are included in the new documentation. This definition file is ported from Dockerfile using spython. Hence, we should create a Github action later to automate this process.