### PR TITLE
Add libtbb2 to Dockerfile.gpu

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -6,7 +6,7 @@ EXPOSE 3000
 USER root
 RUN apt-get update && apt-get install -y curl gpg-agent ca-certificates
 RUN curl --silent --location https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install -y nodejs unzip p7zip-full && npm install -g nodemon && \
+RUN apt-get install -y nodejs unzip p7zip-full libtbb2 && npm install -g nodemon && \
     ln -s /code/SuperBuild/install/bin/untwine /usr/bin/untwine && \
     ln -s /code/SuperBuild/install/bin/entwine /usr/bin/entwine && \
     ln -s /code/SuperBuild/install/bin/pdal /usr/bin/pdal


### PR DESCRIPTION
libtbb2 is need for nodeodm:gpu docker container
see bug #219 