### PR TITLE
fix: support v6 and v7 uuids

### DIFF
--- a/libs/taskNew.js
+++ b/libs/taskNew.js
@@ -99,7 +99,7 @@ module.exports = {
             const userUuid = req.get('set-uuid');
     
             // Valid UUID and no other task with same UUID?
-            if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(userUuid) && !TaskManager.singleton().find(userUuid)){
+            if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(userUuid) && !TaskManager.singleton().find(userUuid)){
                 req.id = userUuid;
                 next();
             }else{


### PR DESCRIPTION
When using `set-uuid` and creating a new task, there is no support for UUID versions of v6 or v7. This change simply updates the current regex rule.

Another option for resolving this issue is to simply remove the version condition from the rule and use a more common rule: i.e. `/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i`.