### PR TITLE
Fix for CUDA init failure

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,5 +1,5 @@
 FROM opendronemap/odm:gpu
-MAINTAINER Piero Toffanin <pt@masseranolabs.com>
+LABEL maintainer="Piero Toffanin <pt@masseranolabs.com>"
 
 EXPOSE 3000
 
@@ -23,6 +23,8 @@ RUN npm install --production && mkdir -p tmp
 
 RUN chown -R odm:odm /var/www
 RUN chown -R odm:odm /code
+
+RUN apt-get remove -y cuda-libraries-11-2 cuda-cudart-11-2 cuda-compat-11-2 cuda-nvrtc-11-2 cuda-nvtx-11-2
 
 USER odm
 


### PR DESCRIPTION
There appear to be conflicts between the container-based CUDA libraries and most host CUDA libraries/Nvidia drivers, such that NodeODM output will complain that CUDA cannot be initialized even though `nvidia-smi` is detected. Removing these packages appears to resolve the conflict without causing any other issues. Installing newer versions of the same does not appear to be necessary.

See this thread for more info: https://community.opendronemap.org/t/opendronemap-nodeodm-gpu-nvidia-smi-detected-cannot-initialize-cuda

Also changed maintainer style to resolve deprecation warnings.

Submitting PR on request from Saijin.