### PR TITLE
Pin nexe and update upload-artifact task

### DIFF
--- a/.github/workflows/publish-windows.yml
+++ b/.github/workflows/publish-windows.yml
@@ -20,12 +20,12 @@ jobs:
     - name: Setup Env
       run: |
         npm i
-        npm i -g nexe
+        npm i -g nexe@4.0.0-rc.7
     - name: Build bundle
       run: |
         npm run winbundle
     - name: Upload Bundle File
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Bundle
         path: dist\*.zip


### PR DESCRIPTION
nexe v5 wasn't working with NodeODM for some reason (outdated Node maybe?), and the existing task stopped working because v2 of upload-artifact is deprecated. nexe v4 works, so pin it to that for now and update the upload-artifact task.