### PR TITLE
Quote params and use shell: true

### DIFF
--- a/libs/odmRunner.js
+++ b/libs/odmRunner.js
@@ -25,6 +25,11 @@ let config = require('../config.js');
 let logger = require('./logger');
 let utils = require('./utils');
 
+const shQuote = s =>  {
+    s = s.replace(/"/g, "")
+    return `"${s}"`;
+}
+
 module.exports = {
     run: function(options, projectName, done, outputReceived){
         assert(projectName !== undefined, "projectName must be specified");
@@ -36,7 +41,7 @@ module.exports = {
         if (os.platform() === "win32"){
             // On Windows, we need to add quotes around the file path
             // otherwise it doesn't work when there are spaces in the path
-            command = `"${command}"`;
+            command = shQuote(command);
         }
 
         for (var name in options){
@@ -49,11 +54,11 @@ module.exports = {
 
             // We don't specify "--time true" (just "--time")
             if (typeof value !== 'boolean'){
-                params.push(value);
+                params.push(shQuote(value));
             }
         }
 
-        params.push(projectName);
+        params.push(shQuote(projectName));
 
         logger.info(`About to run: ${command} ${params.join(" ")}`);
 
@@ -79,7 +84,7 @@ module.exports = {
         // Launch
         const env = utils.clone(process.env);
         env.ODM_NONINTERACTIVE = 1;
-        let childProcess = spawn(command, params, {cwd: config.odm_path, env});
+        let childProcess = spawn(command, params, {cwd: config.odm_path, env, shell: true });
 
         childProcess
             .on('exit', (code, signal) => done(null, code, signal))
@@ -133,10 +138,6 @@ module.exports = {
             const env = utils.clone(process.env);
             env.ODM_OPTIONS_TMP_FILE = utils.tmpPath(".json");
             env.ODM_PATH = config.odm_path;
-            const shQuote = s =>  {
-                s = s.replace(/"/g, "")
-                return `"${s}"`;
-            }
 
             let childProcess = spawn(pythonExe, [shQuote(path.join(__dirname, "..", "helpers", "odmOptionsToJson.py")),
                     "--project-path", shQuote(config.odm_path), "bogusname"], { env, shell: true });


### PR DESCRIPTION
Fixes issue launching processing when NodeODM is installed in a path with a space.